### PR TITLE
Update README.md (Valencia Island tileset)

### DIFF
--- a/Tilesets/The Great Tileset Exchange/Full Tilesets/Valencia Island/README.md
+++ b/Tilesets/The Great Tileset Exchange/Full Tilesets/Valencia Island/README.md
@@ -4,7 +4,7 @@
 - Taken with permission
 - Tile credits in the [PokeCommunity thread](https://www.pokecommunity.com/threads/pokemon-orange-islands.402242/)
 - For pokefirered, but can be used in pokeemerald using [this](https://github.com/ShinyDragonHunter/pokeemerald/commit/b05c124feda40efeb097691412ec79e9afcf3bac) and [this](https://github.com/ShinyDragonHunter/pokeemerald/commit/f1c3c90af995ba3ac9f2818b8016ae20ec487947)
-- Credits to ShinyDragonHunter for the pokeemerald metatile implementation
+- Credits to ShinyDragonHunter for the pokefirered metatile implementation
 - Pal 7 is used in primary tileset
 - **Does not use triple layer metatiles**
 


### PR DESCRIPTION
Should be "pokefirered metatile implementation" instead of pokeemerald.